### PR TITLE
Fix link to tutorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,7 @@ pear install [--alldeps] phing/phing</pre>
                                 <h5 id="Tutorials">Tutorials</h5>
                                 <ul>
                                     <li><a target="_blank"
-                                           href="http://www.davedevelopment.co.uk/2008/04/14/how-to-simple-database-migrations-with-phing-and-dbdeploy">Migrations
+                                           href="https://davedevelopment.co.uk/2008/04/14/how-to-simple-database-migrations-with-phing-and-dbdeploy.html">Migrations
                                         with Phing and DbDeploy</a>
                                     </li>
                                     <li><a target="_blank"


### PR DESCRIPTION
The previous link leads to SSL cert error (cert name is invalid) and the main blog page. 